### PR TITLE
Challengefinalize

### DIFF
--- a/controllers/api/challengeHelpers.js
+++ b/controllers/api/challengeHelpers.js
@@ -35,16 +35,10 @@ const resolve = async (challenge) => {
   const challenger = challenge.attacker;
   const defender = challenge.defender;
 
-  const challengerDetails = Object.keys(weaknessOf).reduce((memo,t) => {
-    if(challenger[`${t}_lvl`] && challenger[`${t}_lvl`] > memo.level){
-      memo.type = t;
-      memo.level = challenger[`${t}_lvl`];
-    }
-    return memo;
-  },{
-    type: '',
-    level:0
-  });
+  const challengerDetails = {
+    type: challenger.type,
+    level: challenger[`${challenger.type}_lvl`]
+  };
 
   const defenderLevel = Object.entries(weaknessOf).reduce((total,[t,w])=>{
     const dLvl = defender[`${t}_lvl`];
@@ -68,7 +62,7 @@ const resolve = async (challenge) => {
     challenge.challenger_id :
     challenge.target_id;
   
-  if(challenge.winner === challenge.challenger_id){
+  if(result > 0){
     awardXP(challenger,defender);
   }else{
     awardXP(defender,challenger);

--- a/controllers/api/challengeHelpers.js
+++ b/controllers/api/challengeHelpers.js
@@ -1,5 +1,21 @@
 const { UserObjects } = require('../../models');
 
+const weaknessOf = {
+  rock:'paper',
+  paper:'scissor',
+  scissor:'rock'
+};
+
+const awardXP = (winner,loser) => {
+  const loserLevel = Object.keys(weaknessOf).reduce((memo,key)=>{
+    if(!loser[`${memo}_lvl`] || loser[`${memo}_lvl`] < loser[`${key}_lvl`]){
+      memo = key;
+    }
+    return memo;
+  });
+  winner.experience += loser[`${loserLevel}_lvl`];
+};
+
 /**
  * Resolves a challenge by comparing relevant levels (and eventually abilities). Results are figured as follows:
  * - Attackers use only their highest level
@@ -15,14 +31,9 @@ const { UserObjects } = require('../../models');
  * @returns {number} - ID of the winner
  */
 const resolve = async (challenge) => {
-  const challenger = await UserObjects.findByPk(challenge.challenge_object);
-  const defender = await UserObjects.findByPk(challenge.target_object);
-  console.log(challenger);
-  const weaknessOf = {
-    rock:'paper',
-    paper:'scissor',
-    scissor:'rock'
-  };
+  console.log('resolving',challenge);
+  const challenger = challenge.attacker;
+  const defender = challenge.defender;
 
   const challengerDetails = Object.keys(weaknessOf).reduce((memo,t) => {
     if(challenger[`${t}_lvl`] && challenger[`${t}_lvl`] > memo.level){
@@ -53,9 +64,15 @@ const resolve = async (challenge) => {
   },0);
 
   const result = challengerDetails.level - defenderLevel;
-  return result > 0 ? 
+  challenge.winner = result > 0 ? 
     challenge.challenger_id :
     challenge.target_id;
+  
+  if(challenge.winner === challenge.challenger_id){
+    awardXP(challenger,defender);
+  }else{
+    awardXP(defender,challenger);
+  }
 };
 
 module.exports = { resolve };

--- a/controllers/api/profileRoutes.js
+++ b/controllers/api/profileRoutes.js
@@ -60,15 +60,46 @@ router.put('/:id', async (req, res) => {
     const userID = req.session.user_id;
     const creature = await UserObjects.findByPk(req.params.id);
     if (creature.user_id !== userID) {
-      res.status(500).json('Cannot access other user creature');
+      res.status(403).json('Cannot access other user creature');
       return;
     }
-    creature.set({
-      rock_lvl: req.body.rock_lvl || creature.rock_lvl,
-      paper_lvl: req.body.paper_lvl || creature.paper_lvl,
-      scissor_lvl: req.body.scissor_lvl || creature.scissor_lvl
-    });
-    creature.save();
+    console.log('comparison',creature.experience >= creature.experience_threshold);
+    if(creature.experience < creature.experience_threshold){
+      return res.status(500).json('insufficient experience');
+    }
+    
+    const validAddTypes = ['rock','paper','scissor'].filter(s => s !== creature.type);
+    const validRx = new RegExp(validAddTypes.join('|'));
+    const primaryLvl = `${creature.type}_lvl`;
+    if(req.body.add_type){
+      if(!validRx.test(req.body.add_type)){
+        return res.status(500).json('Invalid type addition');
+      }else if((creature[primaryLvl] + 1) % 4 !== 0){
+        return res.status(500).json('Cannot multiclass this level');
+      }
+    } 
+
+    const addLvl = req.body.add_type  ?
+      `${req.body.add_type}_lvl` :
+      null;
+    const setObj = {
+      rock_lvl: creature.rock_lvl ?
+        creature.rock_lvl + 1:
+        null,
+      paper_lvl: creature.paper_lvl ?
+        creature.paper_lvl + 1:
+        null,
+      scissor_lvl: creature.scissor_lvl ?
+        creature.scissor_lvl + 1:
+        null,
+      experience: creature.experience - creature.experience_threshold,
+      experience_threshold: creature.experience_threshold + creature[primaryLvl] + 1 
+    };
+    if(addLvl){
+      setObj[addLvl] = (setObj[addLvl] || 0) + 1;
+    }
+    creature.set(setObj);
+    await creature.save();
     res.json(creature);
   } catch (err) {
     console.log(err);

--- a/controllers/api/profileRoutes.js
+++ b/controllers/api/profileRoutes.js
@@ -27,6 +27,7 @@ router.post('/:type', async (req, res) => {
     const newObject = await UserObjects.create({
       user_id: req.session.user_id,
       [`${type}_lvl`]: 1,
+      type,
       img: `/public/portratis/${type}.png`
     });
     res.json(newObject);

--- a/controllers/api/profileRoutes.js
+++ b/controllers/api/profileRoutes.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 const { UserObjects, User } = require("../../models");
 
+// Get all user's creatures
 router.get('/', async (req, res) => {
   try {
     const userID = req.session.user_id;
@@ -47,23 +48,6 @@ router.post('/', async (req, res) => {
       res.status(500).json('starter creatures already made');
       return;
     }
-    const newObjects = await UserObjects.bulkCreate([
-      {
-        user_id: userID,
-        rock_lvl: 1,
-        img: '/public/portraits/rock.png'
-      },
-      {
-        user_id: userID,
-        paper_lvl: 1,
-        img: '/public/portraits/rock.png'
-      },
-      {
-        user_id: userID,
-        scissor_lvl: 1,
-        img: '/public/portraits/rock.png'
-      }
-    ]);
     res.json(newObjects);
   } catch (err) {
     console.log(err);

--- a/controllers/api/userRoutes.js
+++ b/controllers/api/userRoutes.js
@@ -2,8 +2,6 @@ const router = require("express").Router();
 const { TimeoutError } = require("sequelize");
 const { User, UserObjects } = require("../../models");
 
-
-
 router.post("/", async (req, res) => {
   try {
     const userData = await User.create(req.body);
@@ -12,16 +10,19 @@ router.post("/", async (req, res) => {
       {
         user_id: userData.id,
         rock_lvl: 1,
+        type: 'rock',
         img: '/public/portraits/rock.png'
       },
       {
         user_id: userData.id,
         paper_lvl: 1,
+        type: 'paper',
         img: '/public/portraits/paper.png'
       },
       {
         user_id: userData.id,
         scissor_lvl: 1,
+        type: 'scissor',
         img: '/public/portraits/scissor.png'
       }
     ]);

--- a/controllers/api/userRoutes.js
+++ b/controllers/api/userRoutes.js
@@ -1,18 +1,36 @@
 const router = require("express").Router();
 const { TimeoutError } = require("sequelize");
-const { User } = require("../../models");
+const { User, UserObjects } = require("../../models");
 
 
 
 router.post("/", async (req, res) => {
   try {
     const userData = await User.create(req.body);
+    
+    const newObjects = await UserObjects.bulkCreate([
+      {
+        user_id: userData.id,
+        rock_lvl: 1,
+        img: '/public/portraits/rock.png'
+      },
+      {
+        user_id: userData.id,
+        paper_lvl: 1,
+        img: '/public/portraits/paper.png'
+      },
+      {
+        user_id: userData.id,
+        scissor_lvl: 1,
+        img: '/public/portraits/scissor.png'
+      }
+    ]);
 
     req.session.save(() => {
       req.session.user_id = userData.id;
       req.session.logged_in = true;
 
-      res.status(200).json(userData);
+      res.status(200).json({...userData.dataValues,userobjects:newObjects});
     });
   } catch (err) {
     res.status(400).json(err.message);
@@ -21,7 +39,12 @@ router.post("/", async (req, res) => {
 
 router.post('/login', async (req, res) => {
   try {
-    const userData = await User.findOne({ where: { user_name: req.body.user_name } });
+    const userData = await User.findOne({
+      where: { user_name: req.body.user_name },
+      include:[
+        UserObjects
+      ]
+    });
     console.log('body', req.body);
     console.log('userData', userData);
     if (!userData) {

--- a/models/index.js
+++ b/models/index.js
@@ -13,19 +13,49 @@ User.hasMany(Connection,{
 Connection.belongsTo(User,{
   foreignKey:'user_id'
 });
-
+// Transfers.belongsTo(Accounts, { as: 'accountFrom', onDelete: 'cascade', onUpdate: 'no action' });
+// Transfers.belongsTo(Accounts, { as: 'accountTo', onDelete: 'cascade', onUpdate: 'no action' });
 User.hasMany(Challenges,{
-  foreignKey:'challenger_id'
+  foreignKey:'challenger_id',
+  as:'challenger',
+  onDelete:'cascade'
 });
 Challenges.belongsTo(User,{
-  foreignKey:'challenger_id'
+  foreignKey:'challenger_id',
+  as:'challenger',
+  onDelete:'cascade'
 });
-
-User.hasMany(Challenges,{
-  foreignKey:'target_id'
+User.belongsTo(Challenges,{
+  foreignKey:'target_id',
+  as:'target',
+  onDelete:'SET NULL'
 });
 Challenges.belongsTo(User,{
-  foreignKey:'target_id'
+  foreignKey:'target_id',
+  as:'target',
+  onDelete:'SET NULL'
+});
+
+UserObjects.hasMany(Challenges,{
+  foreignKey:'challenge_object',
+  as:'attacker',
+  onDelete:'CASCADE'
+});
+Challenges.belongsTo(UserObjects,{
+  foreignKey:'challenge_object',
+  as:'attacker',
+  onDelete:'CASCADE'
+});
+
+UserObjects.hasMany(Challenges,{
+  foreignKey:'target_object',
+  as: 'defender',
+  onDelete:'SET NULL'
+});
+Challenges.belongsTo(UserObjects,{
+  foreignKey:'target_object',
+  as: 'defender',
+  onDelete:'SET NULL'
 });
 
 User.hasMany(UserObjects,{

--- a/models/userObjects.js
+++ b/models/userObjects.js
@@ -19,6 +19,12 @@ UserObjects.init(
         key: "id",
       }
     },
+    type:{
+      type: DataTypes.STRING,
+      validate:{
+        is: /^(?:scissor|rock|paper)$/
+      }
+    },
     rock_lvl: {
       type: DataTypes.INTEGER,
     },
@@ -38,6 +44,10 @@ UserObjects.init(
     experience_threshold:{
       type: DataTypes.INTEGER,
       defaultValue:1
+    },
+    is_charming:{
+      type: DataTypes.BOOLEAN,
+      defaultValue:false
     }
   },
   {

--- a/models/userObjects.js
+++ b/models/userObjects.js
@@ -31,6 +31,14 @@ UserObjects.init(
     img: {
       type: DataTypes.STRING,
     },
+    experience:{
+      type: DataTypes.INTEGER,
+      defaultValue:0
+    },
+    experience_threshold:{
+      type: DataTypes.INTEGER,
+      defaultValue:1
+    }
   },
   {
     sequelize,

--- a/seeds/seed.js
+++ b/seeds/seed.js
@@ -12,6 +12,7 @@ const userSeedData = require('./userSeedData.json');
     [1,4,8].forEach((n)=>{
       userObjects.push({
         user_id:user.id,
+        type:'rock',
         rock_lvl: n,
         paper_lvl: Math.floor(n/4),
         img:'/public/portraits/rock.png'


### PR DESCRIPTION
## Models
- Added `type` property to `userObjects` to track their primary type. This is set at object creation and should never be edited
- Added `is_charming` property to `userObjects` to track whether a creature is out on a challenge or not.
## Challenge routes
- Award experience to challenge winner
- Checks if the selected creature (attacker or defender) in the challenge is already being used in another challenge

## User Routes
- Added setting of `type` property on the created creatures in the initial account creation

## Profile Routes
- Added setting of `type` property on created creature when creating a single new creature
- Added Handling for leveling up a creature
- Added Ability to multicalss a creature at every 4th level (4, 8, 12, etc).
- Experience required for next level increases with each level (at a rather absurd rate)